### PR TITLE
add startupOnOff startToggle mode for lights and outlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ await client.lights.setLightTemperature({
 
 await client.lights.setStartupOnOff({
   id: 'YOUR_DEVICE_ID',
-  startupOnOff: 'startOn', // 'startOn' | 'startPrevious'
+  startupOnOff: 'startOn', // 'startOn' | 'startPrevious' | 'startToggle'
 })
 ```
 
@@ -358,7 +358,8 @@ await client.outlets.setIsOn({
 
 await client.outlets.setStartupOnOff({
   id: 'YOUR_DEVICE_ID',
-  startupOnOff: 'startOn', // 'startOn' | 'startPrevious'
+  startupOnOff: 'startOn', // 'startOn' | 'startPrevious' | 'startToggle'
+
 })
 
 await client.outlet.setStatusLight({

--- a/src/types/device/Light.ts
+++ b/src/types/device/Light.ts
@@ -12,7 +12,7 @@ export interface LightAttributes
     JoinableDeviceAttributes,
     OtaUpdatableDeviceAttributes {
   isOn: boolean
-  startupOnOff: 'startOn' | 'startPrevious'
+  startupOnOff: 'startOn' | 'startPrevious' | 'startToggle'
   lightLevel: number
   colorHue?: number
   colorSaturation?: number

--- a/src/types/device/Outlet.ts
+++ b/src/types/device/Outlet.ts
@@ -12,7 +12,7 @@ export interface OutletAttributes
     JoinableDeviceAttributes,
     OtaUpdatableDeviceAttributes {
   isOn: boolean
-  startupOnOff: 'startOn' | 'startPrevious'
+  startupOnOff: 'startOn' | 'startPrevious' | 'startToggle'
   lightLevel: number
   startUpCurrentLevel?: number
   currentActivePower?: number


### PR DESCRIPTION
Noticed that startToggle mode was missing for lights and outlets. Tested it out on both lights and outlets, was not sure if it would work for outlets since it is not possible to set within the IKEA app but it works just fine for both.