### PR TITLE
docs: document blinds API based on real-device testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,30 +205,34 @@ await client.airPurifiers.setStatusLight({
 
 #### [Blinds](./src/api/blinds.ts)
 
-Not tested, feedback required.
-
 ```typescript
 const blinds = await client.blinds.list()
 
 const blind = await client.blinds.get({
   id: 'YOUR_DEVICE_ID',
 })
+// blind.attributes.blindsCurrentLevel — where the blind currently is (0–100)
+// blind.attributes.blindsTargetLevel  — where the blind is heading (0–100)
+// blind.attributes.blindsState        — 'stopped' | 'up' | 'down'
+// blind.attributes.batteryPercentage  — battery level of the blind motor
 
-await client.blinds.setCurrentLevel({
-  id: 'YOUR_DEVICE_ID',
-  blindsCurrentLevel: 0,
-})
-
+// Move the blind to a specific level and stop there.
+// 0 = fully up (open), 50 = halfway down, 100 = fully down (closed).
 await client.blinds.setTargetLevel({
   id: 'YOUR_DEVICE_ID',
-  blindsTargetLevel: 60,
+  blindsTargetLevel: 50,
 })
 
+// Start moving the blind continuously up or down, or stop it.
+// The blind stops automatically and sets its state to 'stopped'
+// when it reaches level 0 (fully up) or 100 (fully down).
 await client.blinds.setState({
   id: 'YOUR_DEVICE_ID',
-  blindsState: 'stopped', // 'stopped' | 'up' | 'down'
+  blindsState: 'up', // 'stopped' | 'up' | 'down'
 })
 ```
+
+> **Note:** `setCurrentLevel` is not supported by the hub and returns an API error.
 
 #### [Controllers](./src/api/controllers.ts)
 


### PR DESCRIPTION
## Summary

- Remove "Not tested, feedback required." notice from the blinds section
- Document `blindsTargetLevel` scale: 0 = fully up (open), 100 = fully down (closed)
- Document `setState` behavior: the blind stops automatically and sets state to `stopped` when it reaches level 0 or 100
- Add inline comments on `get` response attributes (`blindsCurrentLevel`, `blindsTargetLevel`, `blindsState`, `batteryPercentage`)
- Note that `setCurrentLevel` is not supported by the hub (returns an API error)

## Test plan

Tested against a real IKEA DIRIGERA hub with an IKEA FYRTUR block-out roller blind:

- [x] `list` — returns all blinds devices
- [x] `get` — returns device with correct attributes and types
- [x] `setTargetLevel` — moves blind to specified level and stops
- [x] `setState` — starts continuous movement; blind stops automatically at level 0 or 100
- [ ] `setCurrentLevel` — not supported by hub, returns `"attributes" does not match any of the allowed types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)